### PR TITLE
Add packaging library to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     'einops>=0.4',
     'einops-exts',
     'numpy',
+    'packaging',
     'pillow',
     'pydantic',
     'pytorch-warmup',


### PR DESCRIPTION
The `packaging` library in one of your most recent commits may not already be installed on a user's device, so it should be in the `setup.py`.

https://github.com/lucidrains/imagen-pytorch/commit/ba0662f18db5ca8cae6bac4861227dcfe46b9992