### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ imagen = Imagen(
     image_sizes = (64, 256),
     beta_schedules = ('cosine', 'linear'),
     timesteps = 1000,
-    cond_drop_prob = 0.5
+    cond_drop_prob = 0.1
 ).cuda()
 
 # mock images (get a lot of this) and text encodings from large T5
@@ -126,7 +126,7 @@ imagen = Imagen(
     image_sizes = (64, 256),
     beta_schedules = ('cosine', 'linear'),
     timesteps = 1000,
-    cond_drop_prob = 0.5
+    cond_drop_prob = 0.1
 ).cuda()
 
 # wrap imagen with the trainer class

--- a/README.md
+++ b/README.md
@@ -51,19 +51,18 @@ imagen = Imagen(
     image_sizes = (64, 256),
     beta_schedules = ('cosine', 'linear'),
     timesteps = 1000,
-    cond_drop_prob = 0.5
+    cond_drop_prob = 0.1
 ).cuda()
 
-# mock images (get a lot of this) and text encodings from large T5
+# mock images and text (get a lot of this)
 
-text_embeds = torch.randn(4, 256, 768).cuda()
-text_masks = torch.ones(4, 256).bool().cuda()
+texts = ['example text'] * 4
 images = torch.randn(4, 3, 256, 256).cuda()
 
 # feed images into imagen, training each unet in the cascade
 
 for i in (1, 2):
-    loss = imagen(images, text_embeds = text_embeds, text_masks = text_masks, unet_number = i)
+    loss = imagen(images, texts = texts, unet_number = i)
     loss.backward()
 
 # do the above for many many many many steps
@@ -111,17 +110,16 @@ imagen = Imagen(
     image_sizes = (64, 256),
     beta_schedules = ('cosine', 'linear'),
     timesteps = 1000,
-    cond_drop_prob = 0.5
+    cond_drop_prob = 0.1
 ).cuda()
 
 # wrap imagen with the trainer class
 
 trainer = ImagenTrainer(imagen)
 
-# mock images (get a lot of this) and text encodings from large T5
+# mock images and text (get a lot of this)
 
-text_embeds = torch.randn(64, 256, 1024).cuda()
-text_masks = torch.ones(64, 256).bool().cuda()
+texts = ['example text'] * 64
 images = torch.randn(64, 3, 256, 256).cuda()
 
 # feed images into imagen, training each unet in the cascade
@@ -129,8 +127,7 @@ images = torch.randn(64, 3, 256, 256).cuda()
 for i in (1, 2):
     loss = trainer(
         images,
-        text_embeds = text_embeds,
-        text_masks = text_masks,
+        texts = texts
         unet_number = i,
         max_batch_size = 4        # auto divide the batch of 64 up into batch size of 4 and accumulate gradients, so it all fits in memory
     )


### PR DESCRIPTION
Two small tweaks to the README.

1. Update `cond_drop_prob` to be 0.1 instead of 0.5, which is the current default value in the Imagen class. Anecdotally, the current value of 0.5 causes the model to ignore text prompts when sampling images with a `cond_prob` value under 5.0.

2. For simplicity's sake in the examples, leave generating the text encodings to the Imagen and only supply `texts`. The examples don't describe how to generate text encodings from T5, and the Imagen model is currently capable of doing that by itself.