### PR TITLE
Type hints

### DIFF
--- a/imagen_pytorch/container_types.py
+++ b/imagen_pytorch/container_types.py
@@ -1,0 +1,5 @@
+from typing import List, Tuple, Union
+from .type_vars import T
+
+_TupleOrList = Union[Tuple[T, ...], List[T]]
+_TupleOrListOrSingle = Union[_TupleOrList[T], T]

--- a/imagen_pytorch/imagen_literal_types.py
+++ b/imagen_pytorch/imagen_literal_types.py
@@ -1,0 +1,4 @@
+from typing import Literal
+_LossType = Literal['l1', 'l2', 'huber']
+_NoiseSchedule = Literal['cosine', 'linear']
+_PredObjective = Literal['noise']

--- a/imagen_pytorch/t5.py
+++ b/imagen_pytorch/t5.py
@@ -37,7 +37,7 @@ def get_model_and_tokenizer(name):
 
     return T5_CONFIGS[name]['model'], T5_CONFIGS[name]['tokenizer']
 
-def get_encoded_dim(name):
+def get_encoded_dim(name: str) -> int:
     if name not in T5_CONFIGS:
         # avoids loading the model if we only want to get the dim
         config = T5Config.from_pretrained(name)

--- a/imagen_pytorch/type_vars.py
+++ b/imagen_pytorch/type_vars.py
@@ -1,0 +1,4 @@
+from typing import TypeVar
+
+T = TypeVar('T')
+U = TypeVar('U')


### PR DESCRIPTION
I was a bit confused about the `Imagen` construction parameters (e.g. what datatype was expected, whether a container thereof was expected, what literal options were allowed for strings).  
It looks like there's a common convention (i.e. anything which `cast_tuple()` can accept), so I've made a generic type `_TupleOrListOrSingle` to explain it.  
I've made explicit literal types for string choices.

I figured it would be desirable to do a length-check on _every_ tuple creation, so I've added a guard inside `cast_tuple()`.

The assertion `num_unets == len(image_sizes)` didn't protect me (if you pass a non-tuple — like `(64)` — then `len(int)` will go bang), so I've removed that (to instead rely on the new `cast_tuple()` assertion).

I tried to target a Python 3.8 featureset, so I preferred `Union` over `|`, avoided tuple literals and avoided explicit `TypeAlias`. I tested on Python 3.9 though, so there's a possibility I'm using functionality newer-than-intended.

I used `from __future__ import annotations` to enable methods of `Unet` to declare that they return a `Unet`.

not sure whether this is idomatic Python; I'm approaching this with my TypeScript hat on 😛 .