### PR TITLE
Unconditional training crashes 

### DIFF
--- a/imagen_pytorch/elucidated_imagen.py
+++ b/imagen_pytorch/elucidated_imagen.py
@@ -435,9 +435,8 @@ class ElucidatedImagen(nn.Module):
             text_embeds, text_masks = t5_encode_text(texts, name = self.text_encoder_name, return_attn_mask = True)
             text_embeds, text_masks = map(lambda t: t.to(device), (text_embeds, text_masks))
 
-        text_masks = default(text_masks, lambda: torch.any(text_embeds != 0., dim = -1))
-
         if not self.unconditional:
+            text_masks = default(text_masks, lambda: torch.any(text_embeds != 0., dim=-1))
             batch_size = text_embeds.shape[0]
 
         assert not (self.condition_on_text and not exists(text_embeds)), 'text or text encodings must be passed into imagen if specified'

--- a/imagen_pytorch/imagen_pytorch.py
+++ b/imagen_pytorch/imagen_pytorch.py
@@ -2091,7 +2091,8 @@ class Imagen(nn.Module):
             text_embeds, text_masks = t5_encode_text(texts, name = self.text_encoder_name, return_attn_mask = True)
             text_embeds, text_masks = map(lambda t: t.to(images.device), (text_embeds, text_masks))
 
-        text_masks = default(text_masks, lambda: torch.any(text_embeds != 0., dim = -1))
+        if not self.unconditional:
+            text_masks = default(text_masks, lambda: torch.any(text_embeds != 0., dim = -1))
 
         assert not (self.condition_on_text and not exists(text_embeds)), 'text or text encodings must be passed into decoder if specified'
         assert not (not self.condition_on_text and exists(text_embeds)), 'decoder specified not to be conditioned on text, yet it is presented'


### PR DESCRIPTION
I might have found a small error for the case of Unconditional training where it crashes because text_embeds does not exist 
in that case. not sure if it can be just put in the 
`if exists(texts) and not exists(text_embeds) and not self.unconditional:`
block above 