### PR TITLE
Update t5.py

### DIFF
--- a/imagen_pytorch/t5.py
+++ b/imagen_pytorch/t5.py
@@ -110,7 +110,7 @@ def t5_encode_text(
     return_attn_mask = False
 ):
     token_ids, attn_mask = t5_tokenize(texts, name = name)
-    encoded_text = t5_encode_tokenized_text(token_ids, attn_mask = attn_mask)
+    encoded_text = t5_encode_tokenized_text(token_ids, attn_mask = attn_mask, name = name)
 
     if return_attn_mask:
         attn_mask = attn_mask.bool()


### PR DESCRIPTION
Subtle bug in text encoding. Doesn't pop up until using a different encoder model with embedding dims that don't match the base model. Code is currently instantiating an entirely new T5 model of 'DEFAULT_T5_NAME' irregardless of what was passed in if name != DEFAULT_T5_NAME.