### PR TITLE
Use default attention mask when pad_id is supplied instead of attn_mask

### DIFF
--- a/imagen_pytorch/t5.py
+++ b/imagen_pytorch/t5.py
@@ -89,9 +89,9 @@ def t5_encode_tokenized_text(
     name = DEFAULT_T5_NAME
 ):
     assert exists(attn_mask) or exists(pad_id)
-    t5, tokenizer = get_model_and_tokenizer(name)
+    t5, _ = get_model_and_tokenizer(name)
 
-    mask = default(attn_mask, lambda: (token_ids != pad_id).long())
+    attn_mask = default(attn_mask, lambda: (token_ids != pad_id).long())
 
     t5.eval()
 


### PR DESCRIPTION
`t5_encode_tokenized_text` accepts a variable `pad_id`, for initializing a basic attention mask (which eliminates pad tokens).  
but this mask was assigned to an unused variable, which meant that the fallback was unused.

the following test program:

```python
from typing import List
from imagen_pytorch.t5 import t5_tokenize, t5_encode_tokenized_text, get_tokenizer

t5_name = 'google/t5-v1_1-small'

texts: List[str] = ['hello world', 'my motherboard hurts']
token_ids, attn_mask = t5_tokenize(texts, name = t5_name)

tokenizer = get_tokenizer(t5_name)

encoded_text = t5_encode_tokenized_text(
  token_ids,
  pad_id=tokenizer.pad_token_id,
  name=t5_name
)
print(encoded_text)
```

would encounter:

```
#  Exception has occurred: AttributeError
#  'NoneType' object has no attribute 'bool'
```

this patch makes the test program return a tensor instead, as intended.