### PR TITLE
load model to CPU first to avoid extra GPU memory usage in 'cuda:0' device

### DIFF
--- a/imagen_pytorch/trainer.py
+++ b/imagen_pytorch/trainer.py
@@ -589,7 +589,8 @@ class ImagenTrainer(nn.Module):
 
         self.reset_ema_unets_all_one_device()
 
-        loaded_obj = torch.load(str(path))
+        # to avoid extra GPU memory usage in main process when using Accelerate
+        loaded_obj = torch.load(str(path), map_location='cpu')
 
         if version.parse(__version__) != version.parse(loaded_obj['version']):
             self.print(f'loading saved imagen at version {loaded_obj["version"]}, but current package version is {__version__}')


### PR DESCRIPTION
`loaded_obj = torch.load(str(path))` will load stat_dict to the default device, `'cuda:0'` here, for **each process**, so there will be extra GPU memory usage in `'cuda:0'` and it is a kind of waste of GPU memory.