### PR TITLE
use optim to get the true lr

### DIFF
--- a/imagen_pytorch/trainer.py
+++ b/imagen_pytorch/trainer.py
@@ -376,10 +376,6 @@ class ImagenTrainer(nn.Module):
         unet_index = unet_number - 1
 
         optim = getattr(self, f'optim{unet_index}')
-        sched = getattr(self, f'scheduler{unet_index}')
-
-        if exists(sched):
-            return sched.get_last_lr()[-1]
 
         return optim.param_groups[0]['lr']
 


### PR DESCRIPTION
if there is a warmup scheduler, the lr provided by other scheduler will be dampened, so the lr obtained from it is not the real one