### PR TITLE
load checkpoint model on cpu first using map_location

### DIFF
--- a/imagen_pytorch/utils.py
+++ b/imagen_pytorch/utils.py
@@ -20,7 +20,7 @@ def load_imagen_from_checkpoint(
     model_path = Path(checkpoint_path)
     full_model_path = str(model_path.resolve())
     assert model_path.exists(), f'checkpoint not found at {full_model_path}'
-    loaded = torch.load(str(model_path))
+    loaded = torch.load(str(model_path), map_location='cpu')
 
     imagen_params = safeget(loaded, 'imagen_params')
     imagen_type = safeget(loaded, 'imagen_type')


### PR DESCRIPTION
Since we don't know what device the network will actually run, map to cpu first.