### PR TITLE
fix error when passing use_tqdm to trainer.sample()

### DIFF
--- a/imagen_pytorch/elucidated_imagen.py
+++ b/imagen_pytorch/elucidated_imagen.py
@@ -4,7 +4,7 @@ from functools import partial
 from contextlib import contextmanager, nullcontext
 from typing import List, Union
 from collections import namedtuple
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import torch
 import torch.nn.functional as F

--- a/imagen_pytorch/imagen_pytorch.py
+++ b/imagen_pytorch/imagen_pytorch.py
@@ -2,7 +2,7 @@ import math
 import copy
 from random import random
 from typing import List, Union
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from functools import partial, wraps
 from contextlib import contextmanager, nullcontext
 from collections import namedtuple

--- a/imagen_pytorch/imagen_video/imagen_video.py
+++ b/imagen_pytorch/imagen_video/imagen_video.py
@@ -1,7 +1,7 @@
 import math
 import copy
 from typing import List
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from functools import partial, wraps
 from contextlib import contextmanager, nullcontext
 from collections import namedtuple

--- a/imagen_pytorch/trainer.py
+++ b/imagen_pytorch/trainer.py
@@ -931,9 +931,11 @@ class ImagenTrainer(nn.Module):
         context = nullcontext if  kwargs.pop('use_non_ema', False) else self.use_ema_unets
 
         self.print_untrained_unets()        
-
+        
+        if not self.is_main:
+            kwargs['use_tqdm'] = False
         with context():
-            output = self.imagen.sample(*args, device = self.device, use_tqdm = self.is_main, **kwargs)
+            output = self.imagen.sample(*args, device = self.device, **kwargs)
 
         return output
 


### PR DESCRIPTION
Passing use_tqdm causes a `got multiple values for keyword argument 'use_tqdm'` error.