### PR TITLE
pass max length to tokenizer to suppress warning message

### DIFF
--- a/imagen_pytorch/t5.py
+++ b/imagen_pytorch/t5.py
@@ -25,7 +25,7 @@ T5_CONFIGS = {}
 # singleton globals
 
 def get_tokenizer(name):
-    tokenizer = T5Tokenizer.from_pretrained(name)
+    tokenizer = T5Tokenizer.from_pretrained(name, model_max_length=MAX_LENGTH)
     return tokenizer
 
 def get_model(name):


### PR DESCRIPTION
currently, when using the built in tokenizer, a warning message is issued at the start of every training:
```
home/$USER/.local/lib/python3.10/site-packages/transformers/models/t5/tokenization_t5.py:163: FutureWarning: This tokenizer was incorrectly instantiated with a model max length of 512 which will be corrected in Transformers v5.
For now, this behavior is kept to avoid breaking backwards compatibility when padding/encoding with `truncation is True`.
- Be aware that you SHOULD NOT rely on t5-large automatically truncating your input to 512 when padding/encoding.
- If you want to encode/pad to sequences longer than 512 you can either instantiate this tokenizer with `model_max_length` or pass `max_length` when encoding/padding.
- To avoid this warning, please instantiate this tokenizer with `model_max_length` set to your preferred value.
```

This PR passes the `MAX_LENGTH` variable to the tokenizer to suppress the warning message and clean up output